### PR TITLE
bump version to 1.7.0 and update dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "quimb" %}
-{% set version = "1.6.0" %}
+{% set version = "1.7.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/quimb-{{ version }}.tar.gz
-  sha256: e7b76af7fc481719d864fa663db6854364ea7ea5bf5e4e7a5748494d072c1c68
+  sha256: 2ca0ddbc650b0fe33154e427e77c6405c572614c61d51e08c55aca7d47fbf0e1
 
 build:
   noarch: python
@@ -28,8 +28,8 @@ requirements:
     - psutil >=4.3.1
     - cytoolz >=0.8.0
     - tqdm >=4
-    - opt-einsum >=3.2
-    - autoray >=0.6.6
+    - autoray >=0.6.7
+    - cotengra >=0.5.6
 
 test:
   imports:


### PR DESCRIPTION
Main change here is moving fully from `opt_einsum` -> `cotengra`.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
